### PR TITLE
Embed all static web content at build time

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -1,5 +1,6 @@
 .DS_Store
 node_modules/
-dist/
 _site
+dist/*
+!dist/gitkeep
 .vscode

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -48,5 +48,6 @@
     "style-loader": "^0.23.1",
     "stylus": "^0.57.0",
     "stylus-loader": "^3.0.2"
-  }
+  },
+  "postinstall": "touch dist/gitkeep"
 }

--- a/main.go
+++ b/main.go
@@ -16,6 +16,7 @@ package main
 
 import (
 	"crypto/subtle"
+	"embed"
 	"flag"
 	"fmt"
 	"net"
@@ -35,6 +36,9 @@ import (
 
 	_ "github.com/falcosecurity/falcosidekick-ui/docs"
 )
+
+//go:embed frontend/dist
+var staticFiles embed.FS
 
 type CustomValidator struct {
 	validator *validator.Validate
@@ -159,8 +163,9 @@ func main() {
 	e.GET("/docs", func(c echo.Context) error {
 		return c.Redirect(http.StatusPermanentRedirect, "docs/")
 	})
-	e.Static("/*", "frontend/dist").Name = "webui-home"
-	e.POST("/", api.AddEvent).Name = AddEvent // for compatibility with old Falcosidekicks
+	// Serve embedded static files found at ./frontend/build
+	e.StaticFS("/*", echo.MustSubFS(staticFiles, "frontend/dist")).Name = "webui-home"
+	e.POST("/", api.AddEvent).Name = "add-event" // for compatibility with old Falcosidekicks
 
 	apiRoute := e.Group("/api/v1")
 	apiRoute.Use(middleware.BasicAuthWithConfig(middleware.BasicAuthConfig{


### PR DESCRIPTION
**What type of PR is this?**
/kind design
/kind feature

**Any specific area of the project related to this PR?**
/area build

**What this PR does / why we need it**:
I am not running falcosidekick-ui from a container, instead just running the process with full filepaths to the binary such as the following. I noticed that each `GET /` call would return "Not Found" instead of showing the web UI.
```
/usr/bin/falcosidekick-ui -r 127.0.0.1:6379 -w testpassword
```

If I ran this instead local to the `frontend/dist/` folder, I was able to successfully see the web UI.
```
cd falcosidekick-ui
./falcosidekick-ui -r 127.0.0.1:6379 -w testpassword
```

I thought that was a bit strange and not something I'd want to deal with again. Using golang's [embed package](https://pkg.go.dev/embed#hdr-Directives) allows for shipping the application and static web assets inside the binary and not having to worry about _how_ someone chooses to run falcosidekick-ui. See [this article for some more information with respect to a golang backend and a vue.js frontend.](https://hackandsla.sh/posts/2021-06-18-embed-vuejs-in-go/)

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
This alters the development workflow on the frontend. To see updated js/css/html/etc you will need to recompile the go binary and re-launch it. The `Dockerfile`s will most likely need to change as a result of this, if the change is accepted.
