### PR TITLE
fix(utils): return 0 instead of crashing on invalid time unit in ConvertToSeconds

### DIFF
--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -98,7 +98,7 @@ func ConvertToSeconds(s string) int {
 	default:
 		o, err := strconv.Atoi(s)
 		if err != nil {
-			WriteLog("fatal", "invalid TTL")
+			return 0
 		}
 		return o
 	}

--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: Apache-2.0
+/*
+Copyright (C) 2023 The Falco Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import "testing"
+
+func TestConvertToSeconds(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  int
+	}{
+		// Valid units
+		{name: "seconds", input: "30s", want: 30},
+		{name: "minutes", input: "5m", want: 300},
+		{name: "hours", input: "2h", want: 7200},
+		{name: "days", input: "1d", want: 86400},
+		{name: "weeks", input: "1w", want: 604800},
+		{name: "months", input: "1M", want: 2592000},
+		{name: "years", input: "1y", want: 31536000},
+		{name: "long form minute", input: "5minute", want: 300},
+		{name: "long form hours", input: "2hours", want: 7200},
+		// Pure numeric (fallback)
+		{name: "pure number", input: "60", want: 60},
+		{name: "zero", input: "0s", want: 0},
+		// Malformed inputs must return 0, not crash
+		{name: "unrecognized suffix", input: "1x", want: 0},
+		{name: "unrecognized suffix a", input: "1a", want: 0},
+		{name: "symbol suffix", input: "1+", want: 0},
+		{name: "multi char bad suffix", input: "5abc", want: 0},
+		{name: "empty string", input: "", want: 0},
+		{name: "only letters", input: "abc", want: 0},
+		{name: "no number prefix", input: "s", want: 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ConvertToSeconds(tt.input)
+			if got != tt.want {
+				t.Errorf("ConvertToSeconds(%q) = %v, want %v", tt.input, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file.
2. Please label this pull request according to what type of issue you are addressing.
3. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build


/area tests


<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

`ConvertToSeconds()` in `internal/utils/utils.go` called `log.Fatalf` (via `WriteLog("fatal", ...)`) when given an unrecognized time unit suffix. Since this function is called with user-supplied `since` query parameters from event endpoints (`/events/count`, `/events/search`), a single malformed request (e.g., `?since=1x`) could crash the entire process, causing a denial-of-service.

This PR replaces the fatal log with `return 0` (treat as "no time filter") and adds 19 unit tests for `ConvertToSeconds` covering valid units, pure numbers, and malformed inputs.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:


